### PR TITLE
Fix problem instanciating queue connection.

### DIFF
--- a/src/LaravelUQueueServiceProvider.php
+++ b/src/LaravelUQueueServiceProvider.php
@@ -48,7 +48,7 @@ class LaravelUQueueServiceProvider extends QueueServiceProvider
     protected function registerRedisConnector($manager)
     {
         $manager->addConnector('redis', function () {
-            return $this->app->make(\Illuminate\Queue\Connectors\RedisConnector::class);
+            return new RedisConnector($this->app['db']);
         });
     }
 
@@ -61,7 +61,7 @@ class LaravelUQueueServiceProvider extends QueueServiceProvider
     protected function registerDatabaseConnector($manager)
     {
         $manager->addConnector('database', function () {
-            return $this->app->make(\Illuminate\Queue\Connectors\DatabaseConnector::class);
+            return new DatabaseConnector($this->app['db']);
         });
     }
 }

--- a/src/LumenUQueueServiceProvider.php
+++ b/src/LumenUQueueServiceProvider.php
@@ -42,7 +42,7 @@ class LumenUQueueServiceProvider extends \Illuminate\Queue\QueueServiceProvider
     protected function registerRedisConnector($manager)
     {
         $manager->addConnector('redis', function () {
-            return $this->app->make(\Illuminate\Queue\Connectors\RedisConnector::class);
+            return new RedisConnector($this->app['db']);
         });
     }
 
@@ -55,7 +55,7 @@ class LumenUQueueServiceProvider extends \Illuminate\Queue\QueueServiceProvider
     protected function registerDatabaseConnector($manager)
     {
         $manager->addConnector('database', function () {
-            return $this->app->make(\Illuminate\Queue\Connectors\DatabaseConnector::class);
+            return new DatabaseConnector($this->app['db']);
         });
     }
 }


### PR DESCRIPTION
Using Laravel Scout, it received this error with the original code:

Illuminate/Contracts/Container/BindingResolutionException with message 'Target [Illuminate/Database/ConnectionResolverInterface] is not instantiable while building [Mingalevme/Illuminate/UQueue/Connectors/DatabaseConnector].

I checked the code in the laravel framework and I modified it to work the same way.

The connector for redis & database require a parameter, and the previous code didn't see to set it.

It now works for me.